### PR TITLE
Fix: connection can't close

### DIFF
--- a/keepalive.go
+++ b/keepalive.go
@@ -31,6 +31,9 @@ func EnableKeepAlive(conn net.Conn) (*Conn, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := file.Close(); err != nil {
+		return nil, err
+	}
 	fd := int(file.Fd())
 	return &Conn{TCPConn: tcp, fd: fd}, nil
 }


### PR DESCRIPTION
In net/conn.File's comment:  sets the underlying os.File to blocking mode and returns a copy. It is the caller's responsibility to close f when finished.Closing c does not affect f, and closing f does not affect c.
